### PR TITLE
WIP LevelSelect Feat

### DIFF
--- a/src/copy_text.rs
+++ b/src/copy_text.rs
@@ -35,4 +35,5 @@ GOAL:
 pub const LEVEL_SELECT: &str = "
 LEVEL SELECT (MICROBAN I)
 =========================
+
 ";

--- a/src/copy_text.rs
+++ b/src/copy_text.rs
@@ -31,3 +31,8 @@ RULES:
 GOAL:
     The puzzle is solved when every GOAL tile is occupied by a BOX.
 ";
+
+pub const LEVEL_SELECT: &str = "
+LEVEL SELECT (MICROBAN I)
+=========================
+";

--- a/src/level_select.rs
+++ b/src/level_select.rs
@@ -13,17 +13,8 @@ use ratatui::{
 
 pub fn view(model: &mut Model, frame: &mut Frame) {
     let mut view_text = copy_text::LEVEL_SELECT.to_string();
-    // Get list of levels by name
-    // let names = model.game.worlds.len();
-    // let worlds_len: String = model.game.worlds.clone().len().to_string();
-    // let current_level = model.game.world_index.to_string();
-    // get range of the levels to display (lets say 8) // might have to be all cool n deldy
-    // append only those hot hot babes
-    // view_text.push_str(&worlds_len);
-    // view_text.push_str(&current_level);
-    view_text.push('\n');
 
-    let selected_index = model.game.world_index;
+    let _world_index = model.game.world_index;
     // Get all of the names as a vector of strings
     let world_names: Vec<String> = model
         .game
@@ -31,7 +22,7 @@ pub fn view(model: &mut Model, frame: &mut Frame) {
         .iter()
         .enumerate() // Get the index of each world
         .map(|(index, world)| {
-            if index == selected_index {
+            if index == _world_index {
                 format!("** {} **\n", world.name) // Highlight the selected world
             } else {
                 format!("   {}\n", world.name) // Normal formatting for other worlds
@@ -39,12 +30,15 @@ pub fn view(model: &mut Model, frame: &mut Frame) {
         })
         .collect();
 
-    // Define the starting index and maximum number of names to show
-    let max_names = 10;
-    let end_index = (selected_index + max_names).min(world_names.len());
+    // TODO: @Lee I tried to do some pretty simple logic but i dont think its in a rusty way. im going to ignore this problem
+    // for now lol
+    // Print 11 rows, with selected in the middle, or otherwise if needed for shorter lists
+    let num_of_rows = std::cmp::min(11, world_names.len());
+
+    let end_index = (_world_index + num_of_rows).min(world_names.len());
 
     // Get the slice of names from the vector
-    let world_names_slice = &world_names[selected_index..end_index];
+    let world_names_slice = &world_names[_world_index..end_index];
     // Join the slice into a single string
     let world_names_joined = world_names_slice.join("");
 

--- a/src/level_select.rs
+++ b/src/level_select.rs
@@ -1,0 +1,50 @@
+use std::io;
+use std::time::Duration;
+
+use crate::{
+    copy_text,
+    types::{LevelSelectAction, Model, RunningState},
+};
+use ratatui::{
+    crossterm::event::{self, Event, KeyCode},
+    widgets::Paragraph,
+    Frame,
+};
+
+pub fn view(_model: &mut Model, frame: &mut Frame) {
+    frame.render_widget(
+        Paragraph::new(copy_text::LEVEL_SELECT.to_string()),
+        frame.area(),
+    );
+}
+
+pub fn update(model: &mut Model, msg: LevelSelectAction) -> Option<LevelSelectAction> {
+    match msg {
+        LevelSelectAction::Quit => {
+            model.running_state = RunningState::Menu;
+        }
+        LevelSelectAction::Select => {
+            model.running_state = RunningState::Game;
+        }
+    };
+    None
+}
+
+pub fn handle_event(_: &Model) -> io::Result<Option<LevelSelectAction>> {
+    if event::poll(Duration::from_millis(250))? {
+        if let Event::Key(key) = event::read()? {
+            if key.kind == event::KeyEventKind::Press {
+                return Ok(handle_key(key));
+            }
+        }
+    }
+    Ok(None)
+}
+
+pub fn handle_key(key: event::KeyEvent) -> Option<LevelSelectAction> {
+    match key.code {
+        KeyCode::Esc => Some(LevelSelectAction::Quit),
+        KeyCode::Enter | KeyCode::Char(' ') => Some(LevelSelectAction::Select),
+        _ => None,
+    }
+}

--- a/src/level_select.rs
+++ b/src/level_select.rs
@@ -15,23 +15,41 @@ pub fn view(model: &mut Model, frame: &mut Frame) {
     let mut view_text = copy_text::LEVEL_SELECT.to_string();
     // Get list of levels by name
     // let names = model.game.worlds.len();
-    let worlds_len: String = model.game.worlds.clone().len().to_string();
-    let current_level = model.game.world_index.to_string();
+    // let worlds_len: String = model.game.worlds.clone().len().to_string();
+    // let current_level = model.game.world_index.to_string();
     // get range of the levels to display (lets say 8) // might have to be all cool n deldy
     // append only those hot hot babes
-    view_text.push_str(&worlds_len);
-    view_text.push_str(&current_level);
+    // view_text.push_str(&worlds_len);
+    // view_text.push_str(&current_level);
     view_text.push('\n');
 
-    // get all of the names as a string
-    let world_names: String = model
+    let selected_index = model.game.world_index;
+    // Get all of the names as a vector of strings
+    let world_names: Vec<String> = model
         .game
         .worlds
-        .iter() // Create an iterator over the Vec
-        .map(|world| format!("{}\n", world.name)) // Append a newline to each name
-        .collect::<Vec<_>>() // Collect into a Vec<String>
-        .join("");
-    view_text.push_str(&world_names);
+        .iter()
+        .enumerate() // Get the index of each world
+        .map(|(index, world)| {
+            if index == selected_index {
+                format!("** {} **\n", world.name) // Highlight the selected world
+            } else {
+                format!("   {}\n", world.name) // Normal formatting for other worlds
+            }
+        })
+        .collect();
+
+    // Define the starting index and maximum number of names to show
+    let max_names = 10;
+    let end_index = (selected_index + max_names).min(world_names.len());
+
+    // Get the slice of names from the vector
+    let world_names_slice = &world_names[selected_index..end_index];
+    // Join the slice into a single string
+    let world_names_joined = world_names_slice.join("");
+
+    // Push the concatenated string to view_text
+    view_text.push_str(&world_names_joined);
 
     frame.render_widget(Paragraph::new(view_text), frame.area());
 }
@@ -44,8 +62,12 @@ pub fn update(model: &mut Model, msg: LevelSelectAction) -> Option<LevelSelectAc
         LevelSelectAction::Select => {
             model.running_state = RunningState::Game;
         }
-        LevelSelectAction::Up => {}
-        LevelSelectAction::Down => {}
+        LevelSelectAction::Up => {
+            model.game.decrement_level();
+        }
+        LevelSelectAction::Down => {
+            model.game.increment_level();
+        }
     };
     None
 }

--- a/src/level_select.rs
+++ b/src/level_select.rs
@@ -11,11 +11,29 @@ use ratatui::{
     Frame,
 };
 
-pub fn view(_model: &mut Model, frame: &mut Frame) {
-    frame.render_widget(
-        Paragraph::new(copy_text::LEVEL_SELECT.to_string()),
-        frame.area(),
-    );
+pub fn view(model: &mut Model, frame: &mut Frame) {
+    let mut view_text = copy_text::LEVEL_SELECT.to_string();
+    // Get list of levels by name
+    // let names = model.game.worlds.len();
+    let worlds_len: String = model.game.worlds.clone().len().to_string();
+    let current_level = model.game.world_index.to_string();
+    // get range of the levels to display (lets say 8) // might have to be all cool n deldy
+    // append only those hot hot babes
+    view_text.push_str(&worlds_len);
+    view_text.push_str(&current_level);
+    view_text.push('\n');
+
+    // get all of the names as a string
+    let world_names: String = model
+        .game
+        .worlds
+        .iter() // Create an iterator over the Vec
+        .map(|world| format!("{}\n", world.name)) // Append a newline to each name
+        .collect::<Vec<_>>() // Collect into a Vec<String>
+        .join("");
+    view_text.push_str(&world_names);
+
+    frame.render_widget(Paragraph::new(view_text), frame.area());
 }
 
 pub fn update(model: &mut Model, msg: LevelSelectAction) -> Option<LevelSelectAction> {
@@ -26,6 +44,8 @@ pub fn update(model: &mut Model, msg: LevelSelectAction) -> Option<LevelSelectAc
         LevelSelectAction::Select => {
             model.running_state = RunningState::Game;
         }
+        LevelSelectAction::Up => {}
+        LevelSelectAction::Down => {}
     };
     None
 }
@@ -41,10 +61,17 @@ pub fn handle_event(_: &Model) -> io::Result<Option<LevelSelectAction>> {
     Ok(None)
 }
 
+// Handle todo: repeating same key logic is kinda clunky. the idea of "up" is the same across the board bro
 pub fn handle_key(key: event::KeyEvent) -> Option<LevelSelectAction> {
     match key.code {
         KeyCode::Esc => Some(LevelSelectAction::Quit),
         KeyCode::Enter | KeyCode::Char(' ') => Some(LevelSelectAction::Select),
+        KeyCode::Up | KeyCode::Char('w') | KeyCode::Char('W') => {
+            Some(LevelSelectAction::Up)
+        }
+        KeyCode::Down | KeyCode::Char('s') | KeyCode::Char('S') => {
+            Some(LevelSelectAction::Down)
+        }
         _ => None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::io::{self, Read, Write};
 
 mod colors;
 mod copy_text;
+mod level_select;
 mod menu;
 mod render;
 mod render_tests;
@@ -102,6 +103,17 @@ fn main() -> io::Result<()> {
                 // Process updates as long as they return a non-None message
                 while current_msg.is_some() {
                     current_msg = soko_game::update(&mut model, current_msg.unwrap());
+                }
+            }
+            types::RunningState::LevelSelect => {
+                terminal.draw(|f| level_select::view(&mut model, f))?;
+                // Handle events and map to a Message
+                let mut current_msg = level_select::handle_event(&model)?;
+
+                // Process updates as long as they return a non-None message
+                while current_msg.is_some() {
+                    current_msg =
+                        level_select::update(&mut model, current_msg.unwrap());
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,6 @@ fn main() -> io::Result<()> {
         }
         None => types::SaveFile::new(),
     };
-    // TODO: what the hell is the business with this game window vs game paradigm?
-    // I need to make my thoughts clean on this when im not solving a problem
     let game_window = types::GameWindow {
         world: worlds[current_world_i].clone(),
         zoom: types::Zoom::Middle,
@@ -95,11 +93,8 @@ fn main() -> io::Result<()> {
                 // When you win a level, move to the next level!
                 // XXX: This has to happen before the while loop below. Why?
                 if let Some(types::GameAction::Win) = current_msg {
-                    current_world_i += 1;
-                    model.game.window.world = worlds[current_world_i].clone();
-                    model.game.reload_world();
-
-                    saves.saves[0].level = current_world_i;
+                    model.game.increment_level();
+                    saves.saves[0].level = model.game.world_index;
                     save_toml_file(save_file, &saves)?;
                     continue;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,8 @@ fn main() -> io::Result<()> {
         }
         None => types::SaveFile::new(),
     };
+    // TODO: what the hell is the business with this game window vs game paradigm?
+    // I need to make my thoughts clean on this when im not solving a problem
     let game_window = types::GameWindow {
         world: worlds[current_world_i].clone(),
         zoom: types::Zoom::Middle,
@@ -64,6 +66,8 @@ fn main() -> io::Result<()> {
         game: types::Game {
             history: Vec::new(),
             window: game_window,
+            worlds: worlds.clone(),
+            world_index: current_world_i,
         },
     };
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -16,7 +16,7 @@ pub fn view(_model: &mut Model, frame: &mut Frame) {
 pub fn update(model: &mut Model, msg: MenuAction) -> Option<MenuAction> {
     match msg {
         MenuAction::StartGame => {
-            model.running_state = RunningState::Game;
+            model.running_state = RunningState::LevelSelect;
         }
         MenuAction::Quit => {
             // You can handle cleanup and exit here

--- a/src/soko_game.rs
+++ b/src/soko_game.rs
@@ -101,15 +101,6 @@ pub fn handle_event(model: &mut Model) -> io::Result<Option<GameAction>> {
     let window = &mut model.game.window;
     window.debug = Vec::new();
 
-    // for entity in window.world.entities.iter() {
-    //     if let Entity::Player(player) = entity {
-    //         window.debug.push(format!("{:?}", player.position.clone()));
-    //     }
-    // }
-    // window
-    //     .debug
-    //     .push(format!("{:?}", &window.world.board.dim()));
-
     if event::poll(Duration::from_millis(250))? {
         if let Event::Key(key) = event::read()? {
             if key.kind == event::KeyEventKind::Press {

--- a/src/soko_game.rs
+++ b/src/soko_game.rs
@@ -36,12 +36,16 @@ pub fn view(model: &mut Model, frame: &mut Frame) {
     );
 }
 
+// TODO: make a one sized fits all handler for "idiot mode" which is when a user is validly
+// in capsloc mode like an idiot. this happens more than you'd ever imagine. a key is right next to it!
 pub fn handle_key(key: event::KeyEvent) -> Option<GameAction> {
     match key.code {
         // Game state
         KeyCode::Esc => Some(GameAction::Quit),
-        KeyCode::Char('z') | KeyCode::Char('u') => Some(GameAction::Undo),
-        KeyCode::Char('r') => Some(GameAction::Reset),
+        KeyCode::Char('z') | KeyCode::Char('Z') | KeyCode::Char('u') => {
+            Some(GameAction::Undo)
+        }
+        KeyCode::Char('r') | KeyCode::Char('R') => Some(GameAction::Reset),
 
         // Movement
         KeyCode::Up | KeyCode::Char('w') | KeyCode::Char('W') => {
@@ -69,7 +73,7 @@ pub fn handle_key(key: event::KeyEvent) -> Option<GameAction> {
 pub fn update(model: &mut Model, msg: GameAction) -> Option<GameAction> {
     let game = &mut model.game;
     match msg {
-        GameAction::Quit => model.running_state = RunningState::Menu,
+        GameAction::Quit => model.running_state = RunningState::LevelSelect,
         GameAction::Move(direction) => {
             if let Some(new_level) = handle_move(&game.window.world, direction) {
                 game.history.push(game.window.world.clone());

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,6 +35,20 @@ pub struct Game {
 }
 
 impl Game {
+    pub fn change_level(self: &mut Game, level_index: usize) {
+        self.world_index = level_index;
+        self.window.world = self.worlds[self.world_index].clone();
+        self.reload_world();
+    }
+
+    pub fn increment_level(self: &mut Game) {
+        self.change_level(self.world_index + 1);
+    }
+
+    pub fn decrement_level(self: &mut Game) {
+        self.change_level(self.world_index - 1);
+    }
+
     /// Erasing your history, erases your past
     pub fn erase_history(self: &mut Game) {
         self.history.clear();

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,6 +29,8 @@ pub struct Save {
 #[derive(Debug)]
 pub struct Game {
     pub window: GameWindow,
+    pub worlds: Vec<World>,
+    pub world_index: usize,
     pub history: Vec<World>,
 }
 
@@ -74,8 +76,8 @@ pub enum MenuAction {
 
 // #[derive(PartialEq)]
 pub enum LevelSelectAction {
-    // Up,
-    // Down,
+    Up,
+    Down,
     Select,
     // PageUp,
     // PageDown,

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,8 +58,10 @@ pub struct Model {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+// XXX: Ambiguous name?
 pub enum RunningState {
     Menu,
+    LevelSelect,
     Game,
     Done,
 }
@@ -67,6 +69,16 @@ pub enum RunningState {
 #[derive(PartialEq)]
 pub enum MenuAction {
     StartGame,
+    Quit,
+}
+
+// #[derive(PartialEq)]
+pub enum LevelSelectAction {
+    // Up,
+    // Down,
+    Select,
+    // PageUp,
+    // PageDown,
     Quit,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,6 +35,8 @@ pub struct Game {
 }
 
 impl Game {
+    // TODO: Should making changes like this be a Result type?
+    // e.g. a failed result could return when you decrement from size 0
     pub fn change_level(self: &mut Game, level_index: usize) {
         self.world_index = level_index;
         self.window.world = self.worlds[self.world_index].clone();
@@ -42,11 +44,15 @@ impl Game {
     }
 
     pub fn increment_level(self: &mut Game) {
-        self.change_level(self.world_index + 1);
+        if self.world_index != self.worlds.len() - 1 {
+            self.change_level(self.world_index + 1);
+        }
     }
 
     pub fn decrement_level(self: &mut Game) {
-        self.change_level(self.world_index - 1);
+        if self.world_index != 0 {
+            self.change_level(self.world_index - 1);
+        }
     }
 
     /// Erasing your history, erases your past


### PR DESCRIPTION
Not ready to merge. I need to make a mockup of what a level select should look like

Think is the first few dozen levels are all labeled like just by a number
but then eventually they get cool games

i think its fine to go through a big list of just 1 , 2 , 3 etc but we might want to consider just kicking the user into the game
especially when we only support one game (microban I)

then when they press backspace or escape they can view the level select and replay levels (it'd immediately show the levels that they haven't finished, and some of the ones they finished, and which cursor is selected (with color maybe? ) 

then yeah just selecting a level as you'd expect with page-down / up as a nice feature, and maybe home and end

and then maybe down the road let the user put in a secret cheat argument to unlock all levels.
if you have any cool ideas to style this page lemme know otherwise ill keep it simple and boring to start anyways

then once this is simply boringly working lets save users number of moves so this level select screen goes hard in the paint