### PR TITLE
First version of tile culling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod render;
 mod render_tests;
 mod soko_game;
 mod soko_loader;
+mod soko_loader_tests;
 mod sprites;
 mod types;
 

--- a/src/soko_game.rs
+++ b/src/soko_game.rs
@@ -106,20 +106,20 @@ pub fn handle_event(model: &mut Model) -> io::Result<Option<GameAction>> {
     //     .debug
     //     .push(format!("{:?}", &window.world.board.dim()));
 
-    if event::poll(Duration::from_millis(250))? {
-        if let Event::Key(key) = event::read()? {
-            if key.kind == event::KeyEventKind::Press {
-                return Ok(handle_key(key));
-            }
-        }
-    }
-
     window.debug.push(format!(
         "\n                Steps: {:?}
         Best Solution: X
         \ntbd... ",
         &model.game.history.len()
     ));
+
+    if event::poll(Duration::from_millis(50))? {
+        if let Event::Key(key) = event::read()? {
+            if key.kind == event::KeyEventKind::Press {
+                return Ok(handle_key(key));
+            }
+        }
+    }
 
     // Prevent handling key events, coincidentally, because it's solved!
     if window.world.is_sokoban_solved() {

--- a/src/soko_loader.rs
+++ b/src/soko_loader.rs
@@ -228,6 +228,10 @@ pub fn cull_tiles(index: [usize; 2], board: &mut Array2<Tile>) -> &Array2<Tile> 
     let [bottom, top, right, left] = directions;
 
     // Figure out what directions we need to check for adjacent emptys
+    //
+    // We could do something programatic here, but this code should never change so I feel that
+    // iterating the edgecases is more clear to the reader than writing some loop to conditionally
+    // build this slice.
     let adjacent_indexes: &[[usize; 2]] = if xi == 0 && yi == 0 {
         &[bottom, right]
     } else if xi == last_col && yi == last_row {
@@ -252,15 +256,15 @@ pub fn cull_tiles(index: [usize; 2], board: &mut Array2<Tile>) -> &Array2<Tile> 
     let is_edge_tile = adjacent_indexes.len() != 4;
     let any_empty = adjacent_indexes
         .iter()
-        .any(|index| matches!(board[*index], Tile::Empty));
+        .any(|&index| matches!(board[index], Tile::Empty));
 
     // If any of the adjacent tiles are Empty or are edge tiles we'll set the current tile to
     // Empty, and recursively check if adjacent tiles should be culled
     if any_empty || is_edge_tile {
         board[[yi, xi]] = Tile::Empty;
-        for index in adjacent_indexes {
-            if let Tile::Floor = board[*index] {
-                cull_tiles(*index, board);
+        for &index in adjacent_indexes {
+            if let Tile::Floor = board[index] {
+                cull_tiles(index, board);
             }
         }
     }

--- a/src/soko_loader.rs
+++ b/src/soko_loader.rs
@@ -189,31 +189,31 @@ pub fn cull_outer_tiles(board: &mut Array2<Tile>) -> &Array2<Tile> {
     // Check first and last column for Floor tiles to cull
     for yi in 0..height {
         if matches!(board[[yi, 0]], Tile::Floor) {
-            cull_tiles([yi, 0], board);
+            cull_tiles((yi, 0), board);
         }
         if matches!(board[[yi, width - 1]], Tile::Floor) {
-            cull_tiles([yi, width - 1], board);
+            cull_tiles((yi, width - 1), board);
         }
     }
     // Check first and last row for Floor tiles to cull
     for xi in 0..width {
         if matches!(board[[0, xi]], Tile::Floor) {
-            cull_tiles([0, xi], board);
+            cull_tiles((0, xi), board);
         }
         if matches!(board[[height - 1, xi]], Tile::Floor) {
-            cull_tiles([height - 1, xi], board);
+            cull_tiles((height - 1, xi), board);
         }
     }
     board
 }
 
-pub fn cull_tiles(index: [usize; 2], board: &mut Array2<Tile>) -> &Array2<Tile> {
+pub fn cull_tiles(index: (usize, usize), board: &mut Array2<Tile>) -> &Array2<Tile> {
     // A guard so we don't cull any non-floor tiles
     if !matches!(board[index], Tile::Floor) {
         return board;
     }
     let (height, width) = board.dim();
-    let [yi, xi] = index;
+    let (yi, xi) = index;
     let last_col = width - 1;
     let last_row = height - 1;
 
@@ -248,7 +248,7 @@ pub fn cull_tiles(index: [usize; 2], board: &mut Array2<Tile>) -> &Array2<Tile> 
         board[[yi, xi]] = Tile::Empty;
         for index in adjacent_indexes {
             if matches!(board[index], Tile::Floor) {
-                cull_tiles(index.into(), board);
+                cull_tiles(index, board);
             }
         }
     }

--- a/src/soko_loader.rs
+++ b/src/soko_loader.rs
@@ -217,10 +217,7 @@ pub fn cull_tiles(index: [usize; 2], board: &mut Array2<Tile>) -> &Array2<Tile> 
     let last_col = width - 1;
     let last_row = height - 1;
 
-    // We'll use wrapping subration here because the adjacent_indexes slice further down is set up
-    // to not include the wrapping indexes.
     let directions = [(1, 0), (-1, 0), (0, 1), (0, -1)];
-
     let adjacent_indexes: Vec<(usize, usize)> = directions
         .into_iter()
         .filter_map(|(dir_y, dir_x)| {

--- a/src/soko_loader.rs
+++ b/src/soko_loader.rs
@@ -165,12 +165,18 @@ fn parse_sokoban_level(tokens: &[Token]) -> Result<World, String> {
                 }
                 x += 1;
             }
-            let board = cull_outer_tiles(&mut board);
+
+            // XXX: Fix call_outer_tiles so we only need to call once
+            let (height, width) = board.dim();
+            let max_dim = std::cmp::max(height, width);
+            for _ in 0..(max_dim / 2) {
+                cull_outer_tiles(&mut board);
+            }
 
             // Create an instance of Level
             let level = World {
                 name: title.to_string(),
-                board: board.clone(),
+                board,
                 entities,
                 camera_position: Coordinate { x: 0, y: 0 },
             };

--- a/src/soko_loader.rs
+++ b/src/soko_loader.rs
@@ -247,7 +247,7 @@ pub fn cull_tiles(index: [usize; 2], board: &mut Array2<Tile>) -> &Array2<Tile> 
     if any_empty || is_edge_tile {
         board[[yi, xi]] = Tile::Empty;
         for index in adjacent_indexes {
-            if let Tile::Floor = board[index] {
+            if matches!(board[index], Tile::Floor) {
                 cull_tiles(index.into(), board);
             }
         }

--- a/src/soko_loader.rs
+++ b/src/soko_loader.rs
@@ -186,11 +186,22 @@ fn parse_sokoban_level(tokens: &[Token]) -> Result<World, String> {
 /// any floor tiles with an empty neighbour.
 pub fn cull_outer_tiles(board: &mut Array2<Tile>) -> &Array2<Tile> {
     let (height, width) = board.dim();
-    for yi in 0..(height) {
-        for xi in 0..(width) {
-            if matches!(board[[yi, xi]], Tile::Floor) {
-                cull_tiles([yi, xi], board);
-            }
+    // Check first and last column for Floor tiles to cull
+    for yi in 0..height {
+        if matches!(board[[yi, 0]], Tile::Floor) {
+            cull_tiles([yi, 0], board);
+        }
+        if matches!(board[[yi, width - 1]], Tile::Floor) {
+            cull_tiles([yi, width - 1], board);
+        }
+    }
+    // Check first and last row for Floor tiles to cull
+    for xi in 0..width {
+        if matches!(board[[0, xi]], Tile::Floor) {
+            cull_tiles([0, xi], board);
+        }
+        if matches!(board[[height - 1, xi]], Tile::Floor) {
+            cull_tiles([height - 1, xi], board);
         }
     }
     board

--- a/src/soko_loader_tests.rs
+++ b/src/soko_loader_tests.rs
@@ -214,12 +214,12 @@ mod tests {
             [Tile::Empty, Tile::Floor, Tile::Empty],
             [Tile::Wall, Tile::Empty, Tile::Wall],
         ];
+        // Expected board remains the same
+        let expected = board.clone();
 
         // Apply culling
         cull_outer_tiles(&mut board);
 
-        // Expected board remains the same
-        let expected = board.clone();
         assert_eq!(board, expected);
     }
 
@@ -231,12 +231,12 @@ mod tests {
             [Tile::Wall, Tile::Floor, Tile::Wall],
             [Tile::Wall, Tile::Wall, Tile::Wall],
         ];
+        // Expected board remains the same since the inner Floor tile is not connected to the edge
+        let expected = board.clone();
 
         // Apply culling
         cull_outer_tiles(&mut board);
 
-        // Expected board remains the same since the inner Floor tile is not connected to the edge
-        let expected = board.clone();
         assert_eq!(board, expected);
     }
 
@@ -307,12 +307,12 @@ mod tests {
             [Tile::Wall, Tile::Floor, Tile::Floor, Tile::Floor, Tile::Wall],
             [Tile::Wall, Tile::Wall, Tile::Wall, Tile::Wall, Tile::Wall],
         ];
+        // Expected board remains the same since the Floor tiles are not connected to the edge
+        let expected = board.clone();
 
         // Apply culling
         cull_outer_tiles(&mut board);
 
-        // Expected board remains the same since the Floor tiles are not connected to the edge
-        let expected = board.clone();
         assert_eq!(board, expected);
     }
 }

--- a/src/soko_loader_tests.rs
+++ b/src/soko_loader_tests.rs
@@ -10,7 +10,7 @@ mod tests {
         let mut board = Array2::from_elem((3, 3), Tile::Floor);
 
         // Cull the tile at position (0, 1) which is on the top edge
-        cull_tiles([0, 1], &mut board);
+        cull_tiles((0, 1), &mut board);
 
         // The tile at (0,1) should become Empty
         assert_eq!(board[[0, 1]], Tile::Empty);
@@ -25,7 +25,7 @@ mod tests {
         board[[1, 1]] = Tile::Empty;
 
         // Cull the tile at position (1, 0) which is adjacent to an Empty tile
-        cull_tiles([1, 0], &mut board);
+        cull_tiles((1, 0), &mut board);
 
         // The tile at (1, 0) should become Empty
         assert_eq!(board[[1, 0]], Tile::Empty);
@@ -40,7 +40,7 @@ mod tests {
         board[[0, 1]] = Tile::Empty;
 
         // Cull the tile at position (1, 1), which is adjacent to (0,1)
-        cull_tiles([1, 1], &mut board);
+        cull_tiles((1, 1), &mut board);
 
         // The tile at (1,1) and its adjacent tiles should become Empty recursively
         assert_eq!(board[[1, 1]], Tile::Empty);
@@ -59,7 +59,7 @@ mod tests {
         board[[1, 2]] = Tile::Goal;
 
         // Cull starting from position (0, 1)
-        cull_tiles([0, 1], &mut board);
+        cull_tiles((0, 1), &mut board);
 
         // The Wall and Goal should remain unaffected
         assert_eq!(board[[1, 1]], Tile::Wall);
@@ -77,7 +77,7 @@ mod tests {
         let mut board = Array2::from_elem((5, 5), Tile::Floor);
 
         // Cull starting from position (2, 2) (center tile)
-        cull_tiles([2, 2], &mut board);
+        cull_tiles((2, 2), &mut board);
 
         // Since the center tile is not adjacent to any Empty tiles or edges, it should remain Floor
         assert_eq!(board[[2, 2]], Tile::Floor);
@@ -89,7 +89,7 @@ mod tests {
         let mut board = Array2::from_elem((5, 5), Tile::Floor);
 
         // Cull starting from position (0, 2) (top edge)
-        cull_tiles([0, 2], &mut board);
+        cull_tiles((0, 2), &mut board);
 
         // Tiles should be culled recursively inwards from the edge
         // The tiles in the first row should be Empty
@@ -108,7 +108,7 @@ mod tests {
         let mut board = Array2::from_elem((3, 3), Tile::Floor);
 
         // Cull starting from position (0, 0) (top-left corner)
-        cull_tiles([0, 0], &mut board);
+        cull_tiles((0, 0), &mut board);
 
         // Ensure that the tiles are culled correctly without index underflow
         assert_eq!(board[[0, 0]], Tile::Empty);

--- a/src/soko_loader_tests.rs
+++ b/src/soko_loader_tests.rs
@@ -1,0 +1,116 @@
+#[cfg(test)]
+use crate::{soko_loader::*, types::Tile};
+#[cfg(test)]
+use ndarray::Array2;
+
+#[test]
+fn test_cull_single_floor_tile_on_edge() {
+    // Create a 3x3 board with Floor tiles
+    let mut board = Array2::from_elem((3, 3), Tile::Floor);
+
+    // Cull the tile at position (0, 1) which is on the top edge
+    cull_tiles([0, 1], &mut board);
+
+    // The tile at (0,1) should become Empty
+    assert_eq!(board[[0, 1]], Tile::Empty);
+}
+
+#[test]
+fn test_cull_tile_with_adjacent_empty() {
+    // Create a 3x3 board with Floor tiles
+    let mut board = Array2::from_elem((3, 3), Tile::Floor);
+
+    // Set one tile to Empty
+    board[[1, 1]] = Tile::Empty;
+
+    // Cull the tile at position (1, 0) which is adjacent to an Empty tile
+    cull_tiles([1, 0], &mut board);
+
+    // The tile at (1, 0) should become Empty
+    assert_eq!(board[[1, 0]], Tile::Empty);
+}
+
+#[test]
+fn test_cull_recursively_adjacent_tiles() {
+    // Create a 3x3 board with Floor tiles
+    let mut board = Array2::from_elem((3, 3), Tile::Floor);
+
+    // Set a tile on the edge to Empty
+    board[[0, 1]] = Tile::Empty;
+
+    // Cull the tile at position (1, 1), which is adjacent to (0,1)
+    cull_tiles([1, 1], &mut board);
+
+    // The tile at (1,1) and its adjacent tiles should become Empty recursively
+    assert_eq!(board[[1, 1]], Tile::Empty);
+    assert_eq!(board[[1, 2]], Tile::Empty);
+    assert_eq!(board[[2, 1]], Tile::Empty);
+    assert_eq!(board[[1, 0]], Tile::Empty);
+}
+
+#[test]
+fn test_cull_does_not_affect_walls_and_goals() {
+    // Create a 3x3 board with Floor tiles
+    let mut board = Array2::from_elem((3, 3), Tile::Floor);
+
+    // Place a Wall and a Goal on the board
+    board[[1, 1]] = Tile::Wall;
+    board[[1, 2]] = Tile::Goal;
+
+    // Cull starting from position (0, 1)
+    cull_tiles([0, 1], &mut board);
+
+    // The Wall and Goal should remain unaffected
+    assert_eq!(board[[1, 1]], Tile::Wall);
+    assert_eq!(board[[1, 2]], Tile::Goal);
+
+    // Adjacent Floor tiles should be culled to Empty
+    assert_eq!(board[[0, 1]], Tile::Empty);
+    assert_eq!(board[[0, 0]], Tile::Empty);
+    assert_eq!(board[[0, 2]], Tile::Empty);
+}
+
+#[test]
+fn test_cull_no_effect_on_interior_tile_with_no_adjacent_empty_or_edge() {
+    // Create a 5x5 board with Floor tiles
+    let mut board = Array2::from_elem((5, 5), Tile::Floor);
+
+    // Cull starting from position (2, 2) (center tile)
+    cull_tiles([2, 2], &mut board);
+
+    // Since the center tile is not adjacent to any Empty tiles or edges, it should remain Floor
+    assert_eq!(board[[2, 2]], Tile::Floor);
+}
+
+#[test]
+fn test_cull_edge_tiles_cause_recursive_culling_inwards() {
+    // Create a 5x5 board with Floor tiles
+    let mut board = Array2::from_elem((5, 5), Tile::Floor);
+
+    // Cull starting from position (0, 2) (top edge)
+    cull_tiles([0, 2], &mut board);
+
+    // Tiles should be culled recursively inwards from the edge
+    // The tiles in the first row should be Empty
+    for x in 0..5 {
+        assert_eq!(board[[0, x]], Tile::Empty);
+    }
+
+    // The adjacent tiles should be culled
+    assert_eq!(board[[1, 2]], Tile::Empty);
+    assert_eq!(board[[2, 2]], Tile::Empty);
+}
+
+#[test]
+fn test_cull_tiles_with_wrapping_sub_at_zero_index() {
+    // Create a 3x3 board with Floor tiles
+    let mut board = Array2::from_elem((3, 3), Tile::Floor);
+
+    // Cull starting from position (0, 0) (top-left corner)
+    cull_tiles([0, 0], &mut board);
+
+    // Ensure that the tiles are culled correctly without index underflow
+    assert_eq!(board[[0, 0]], Tile::Empty);
+    assert_eq!(board[[0, 1]], Tile::Empty);
+    assert_eq!(board[[1, 0]], Tile::Empty);
+}

--- a/src/soko_loader_tests.rs
+++ b/src/soko_loader_tests.rs
@@ -1,116 +1,318 @@
 #[cfg(test)]
-use crate::{soko_loader::*, types::Tile};
-#[cfg(test)]
-use ndarray::Array2;
+mod tests {
+    use crate::{soko_loader::*, types::Tile};
+    use ndarray::array;
+    use ndarray::Array2;
 
-#[test]
-fn test_cull_single_floor_tile_on_edge() {
-    // Create a 3x3 board with Floor tiles
-    let mut board = Array2::from_elem((3, 3), Tile::Floor);
+    #[test]
+    fn test_cull_single_floor_tile_on_edge() {
+        // Create a 3x3 board with Floor tiles
+        let mut board = Array2::from_elem((3, 3), Tile::Floor);
 
-    // Cull the tile at position (0, 1) which is on the top edge
-    cull_tiles([0, 1], &mut board);
+        // Cull the tile at position (0, 1) which is on the top edge
+        cull_tiles([0, 1], &mut board);
 
-    // The tile at (0,1) should become Empty
-    assert_eq!(board[[0, 1]], Tile::Empty);
-}
-
-#[test]
-fn test_cull_tile_with_adjacent_empty() {
-    // Create a 3x3 board with Floor tiles
-    let mut board = Array2::from_elem((3, 3), Tile::Floor);
-
-    // Set one tile to Empty
-    board[[1, 1]] = Tile::Empty;
-
-    // Cull the tile at position (1, 0) which is adjacent to an Empty tile
-    cull_tiles([1, 0], &mut board);
-
-    // The tile at (1, 0) should become Empty
-    assert_eq!(board[[1, 0]], Tile::Empty);
-}
-
-#[test]
-fn test_cull_recursively_adjacent_tiles() {
-    // Create a 3x3 board with Floor tiles
-    let mut board = Array2::from_elem((3, 3), Tile::Floor);
-
-    // Set a tile on the edge to Empty
-    board[[0, 1]] = Tile::Empty;
-
-    // Cull the tile at position (1, 1), which is adjacent to (0,1)
-    cull_tiles([1, 1], &mut board);
-
-    // The tile at (1,1) and its adjacent tiles should become Empty recursively
-    assert_eq!(board[[1, 1]], Tile::Empty);
-    assert_eq!(board[[1, 2]], Tile::Empty);
-    assert_eq!(board[[2, 1]], Tile::Empty);
-    assert_eq!(board[[1, 0]], Tile::Empty);
-}
-
-#[test]
-fn test_cull_does_not_affect_walls_and_goals() {
-    // Create a 3x3 board with Floor tiles
-    let mut board = Array2::from_elem((3, 3), Tile::Floor);
-
-    // Place a Wall and a Goal on the board
-    board[[1, 1]] = Tile::Wall;
-    board[[1, 2]] = Tile::Goal;
-
-    // Cull starting from position (0, 1)
-    cull_tiles([0, 1], &mut board);
-
-    // The Wall and Goal should remain unaffected
-    assert_eq!(board[[1, 1]], Tile::Wall);
-    assert_eq!(board[[1, 2]], Tile::Goal);
-
-    // Adjacent Floor tiles should be culled to Empty
-    assert_eq!(board[[0, 1]], Tile::Empty);
-    assert_eq!(board[[0, 0]], Tile::Empty);
-    assert_eq!(board[[0, 2]], Tile::Empty);
-}
-
-#[test]
-fn test_cull_no_effect_on_interior_tile_with_no_adjacent_empty_or_edge() {
-    // Create a 5x5 board with Floor tiles
-    let mut board = Array2::from_elem((5, 5), Tile::Floor);
-
-    // Cull starting from position (2, 2) (center tile)
-    cull_tiles([2, 2], &mut board);
-
-    // Since the center tile is not adjacent to any Empty tiles or edges, it should remain Floor
-    assert_eq!(board[[2, 2]], Tile::Floor);
-}
-
-#[test]
-fn test_cull_edge_tiles_cause_recursive_culling_inwards() {
-    // Create a 5x5 board with Floor tiles
-    let mut board = Array2::from_elem((5, 5), Tile::Floor);
-
-    // Cull starting from position (0, 2) (top edge)
-    cull_tiles([0, 2], &mut board);
-
-    // Tiles should be culled recursively inwards from the edge
-    // The tiles in the first row should be Empty
-    for x in 0..5 {
-        assert_eq!(board[[0, x]], Tile::Empty);
+        // The tile at (0,1) should become Empty
+        assert_eq!(board[[0, 1]], Tile::Empty);
     }
 
-    // The adjacent tiles should be culled
-    assert_eq!(board[[1, 2]], Tile::Empty);
-    assert_eq!(board[[2, 2]], Tile::Empty);
-}
+    #[test]
+    fn test_cull_tile_with_adjacent_empty() {
+        // Create a 3x3 board with Floor tiles
+        let mut board = Array2::from_elem((3, 3), Tile::Floor);
 
-#[test]
-fn test_cull_tiles_with_wrapping_sub_at_zero_index() {
-    // Create a 3x3 board with Floor tiles
-    let mut board = Array2::from_elem((3, 3), Tile::Floor);
+        // Set one tile to Empty
+        board[[1, 1]] = Tile::Empty;
 
-    // Cull starting from position (0, 0) (top-left corner)
-    cull_tiles([0, 0], &mut board);
+        // Cull the tile at position (1, 0) which is adjacent to an Empty tile
+        cull_tiles([1, 0], &mut board);
 
-    // Ensure that the tiles are culled correctly without index underflow
-    assert_eq!(board[[0, 0]], Tile::Empty);
-    assert_eq!(board[[0, 1]], Tile::Empty);
-    assert_eq!(board[[1, 0]], Tile::Empty);
+        // The tile at (1, 0) should become Empty
+        assert_eq!(board[[1, 0]], Tile::Empty);
+    }
+
+    #[test]
+    fn test_cull_recursively_adjacent_tiles() {
+        // Create a 3x3 board with Floor tiles
+        let mut board = Array2::from_elem((3, 3), Tile::Floor);
+
+        // Set a tile on the edge to Empty
+        board[[0, 1]] = Tile::Empty;
+
+        // Cull the tile at position (1, 1), which is adjacent to (0,1)
+        cull_tiles([1, 1], &mut board);
+
+        // The tile at (1,1) and its adjacent tiles should become Empty recursively
+        assert_eq!(board[[1, 1]], Tile::Empty);
+        assert_eq!(board[[1, 2]], Tile::Empty);
+        assert_eq!(board[[2, 1]], Tile::Empty);
+        assert_eq!(board[[1, 0]], Tile::Empty);
+    }
+
+    #[test]
+    fn test_cull_does_not_affect_walls_and_goals() {
+        // Create a 3x3 board with Floor tiles
+        let mut board = Array2::from_elem((3, 3), Tile::Floor);
+
+        // Place a Wall and a Goal on the board
+        board[[1, 1]] = Tile::Wall;
+        board[[1, 2]] = Tile::Goal;
+
+        // Cull starting from position (0, 1)
+        cull_tiles([0, 1], &mut board);
+
+        // The Wall and Goal should remain unaffected
+        assert_eq!(board[[1, 1]], Tile::Wall);
+        assert_eq!(board[[1, 2]], Tile::Goal);
+
+        // Adjacent Floor tiles should be culled to Empty
+        assert_eq!(board[[0, 1]], Tile::Empty);
+        assert_eq!(board[[0, 0]], Tile::Empty);
+        assert_eq!(board[[0, 2]], Tile::Empty);
+    }
+
+    #[test]
+    fn test_cull_no_effect_on_interior_tile_with_no_adjacent_empty_or_edge() {
+        // Create a 5x5 board with Floor tiles
+        let mut board = Array2::from_elem((5, 5), Tile::Floor);
+
+        // Cull starting from position (2, 2) (center tile)
+        cull_tiles([2, 2], &mut board);
+
+        // Since the center tile is not adjacent to any Empty tiles or edges, it should remain Floor
+        assert_eq!(board[[2, 2]], Tile::Floor);
+    }
+
+    #[test]
+    fn test_cull_edge_tiles_cause_recursive_culling_inwards() {
+        // Create a 5x5 board with Floor tiles
+        let mut board = Array2::from_elem((5, 5), Tile::Floor);
+
+        // Cull starting from position (0, 2) (top edge)
+        cull_tiles([0, 2], &mut board);
+
+        // Tiles should be culled recursively inwards from the edge
+        // The tiles in the first row should be Empty
+        for x in 0..5 {
+            assert_eq!(board[[0, x]], Tile::Empty);
+        }
+
+        // The adjacent tiles should be culled
+        assert_eq!(board[[1, 2]], Tile::Empty);
+        assert_eq!(board[[2, 2]], Tile::Empty);
+    }
+
+    #[test]
+    fn test_cull_tiles_with_wrapping_sub_at_zero_index() {
+        // Create a 3x3 board with Floor tiles
+        let mut board = Array2::from_elem((3, 3), Tile::Floor);
+
+        // Cull starting from position (0, 0) (top-left corner)
+        cull_tiles([0, 0], &mut board);
+
+        // Ensure that the tiles are culled correctly without index underflow
+        assert_eq!(board[[0, 0]], Tile::Empty);
+        assert_eq!(board[[0, 1]], Tile::Empty);
+        assert_eq!(board[[1, 0]], Tile::Empty);
+    }
+
+    #[test]
+    fn test_cull_empty_board() {
+        // Create an empty board (all tiles are Empty)
+        let mut board = Array2::from_elem((3, 3), Tile::Empty);
+
+        // Apply culling
+        cull_outer_tiles(&mut board);
+
+        // Expected board remains the same
+        let expected = Array2::from_elem((3, 3), Tile::Empty);
+        assert_eq!(board, expected);
+    }
+
+    #[test]
+    fn test_cull_full_floor_board() {
+        // Create a board where all tiles are Floor
+        let mut board = Array2::from_elem((3, 3), Tile::Floor);
+
+        // Apply culling
+        cull_outer_tiles(&mut board);
+
+        // Expected board after culling recursively
+        let expected = Array2::from_elem((3, 3), Tile::Empty);
+        assert_eq!(board, expected);
+    }
+
+    #[test]
+    fn test_cull_with_walls_and_goals() {
+        // Create a board with Walls and Goals on the edges and Floors inside
+        let mut board = array![
+            [Tile::Wall, Tile::Goal, Tile::Wall],
+            [Tile::Floor, Tile::Floor, Tile::Floor],
+            [Tile::Wall, Tile::Goal, Tile::Wall],
+        ];
+
+        // Apply culling
+        cull_outer_tiles(&mut board);
+
+        // Expected board after culling recursively
+        let expected = array![
+            [Tile::Wall, Tile::Goal, Tile::Wall],
+            [Tile::Empty, Tile::Empty, Tile::Empty],
+            [Tile::Wall, Tile::Goal, Tile::Wall],
+        ];
+
+        assert_eq!(board, expected);
+    }
+
+    #[test]
+    fn test_cull_partial_floor_edges() {
+        // Create a board with some Floor tiles on the edges connected to inner floors
+        let mut board = array![
+            [Tile::Empty, Tile::Floor, Tile::Empty],
+            [Tile::Floor, Tile::Floor, Tile::Floor],
+            [Tile::Empty, Tile::Floor, Tile::Empty],
+        ];
+
+        // Apply culling
+        cull_outer_tiles(&mut board);
+
+        // Expected board after culling recursively
+        let expected = array![
+            [Tile::Empty, Tile::Empty, Tile::Empty],
+            [Tile::Empty, Tile::Empty, Tile::Empty],
+            [Tile::Empty, Tile::Empty, Tile::Empty],
+        ];
+
+        assert_eq!(board, expected);
+    }
+
+    #[test]
+    fn test_cull_larger_board() {
+        // Create a 5x5 board with Floor tiles
+        let mut board = Array2::from_elem((5, 5), Tile::Floor);
+
+        // Set some inner tiles to Wall and Goal
+        board[[2, 2]] = Tile::Wall;
+        board[[1, 3]] = Tile::Goal;
+
+        // Apply culling
+        cull_outer_tiles(&mut board);
+
+        // Expected board after culling recursively
+        let mut expected = Array2::from_elem((5, 5), Tile::Empty);
+        expected[[2, 2]] = Tile::Wall;
+        expected[[1, 3]] = Tile::Goal;
+
+        assert_eq!(board, expected);
+    }
+
+    #[test]
+    fn test_cull_no_floor_on_edges() {
+        // Create a board with no Floor tiles on the edges
+        let mut board = array![
+            [Tile::Wall, Tile::Empty, Tile::Wall],
+            [Tile::Empty, Tile::Floor, Tile::Empty],
+            [Tile::Wall, Tile::Empty, Tile::Wall],
+        ];
+
+        // Apply culling
+        cull_outer_tiles(&mut board);
+
+        // Expected board remains the same
+        let expected = board.clone();
+        assert_eq!(board, expected);
+    }
+
+    #[test]
+    fn test_cull_inner_floor_tile_not_connected_to_edge() {
+        // Create a board with an inner floor tile completely enclosed by walls
+        let mut board = array![
+            [Tile::Wall, Tile::Wall, Tile::Wall],
+            [Tile::Wall, Tile::Floor, Tile::Wall],
+            [Tile::Wall, Tile::Wall, Tile::Wall],
+        ];
+
+        // Apply culling
+        cull_outer_tiles(&mut board);
+
+        // Expected board remains the same since the inner Floor tile is not connected to the edge
+        let expected = board.clone();
+        assert_eq!(board, expected);
+    }
+
+    #[test]
+    fn test_cull_complex_pattern() {
+        // Create a complex board pattern with Floors connected to the edge
+        #[rustfmt::skip]
+        let mut board = array![
+            [Tile::Floor, Tile::Wall, Tile::Floor, Tile::Wall, Tile::Floor],
+            [Tile::Wall, Tile::Floor, Tile::Floor, Tile::Floor, Tile::Wall],
+            [Tile::Floor, Tile::Floor, Tile::Goal, Tile::Floor, Tile::Floor],
+            [Tile::Wall, Tile::Floor, Tile::Floor, Tile::Floor, Tile::Wall],
+            [Tile::Floor, Tile::Wall, Tile::Floor, Tile::Wall, Tile::Floor],
+        ];
+
+        // Apply culling
+        cull_outer_tiles(&mut board);
+
+        // Expected board after culling recursively
+        #[rustfmt::skip]
+        let expected = array![
+            [Tile::Empty, Tile::Wall, Tile::Empty, Tile::Wall, Tile::Empty],
+            [Tile::Wall, Tile::Empty, Tile::Empty, Tile::Empty, Tile::Wall],
+            [Tile::Empty, Tile::Empty, Tile::Goal, Tile::Empty, Tile::Empty],
+            [Tile::Wall, Tile::Empty, Tile::Empty, Tile::Empty, Tile::Wall],
+            [Tile::Empty, Tile::Wall, Tile::Empty, Tile::Wall, Tile::Empty],
+        ];
+
+        assert_eq!(board, expected);
+    }
+
+    #[test]
+    fn test_cull_tiles_connected_to_edge() {
+        // Create a board where floor tiles are connected to the edge
+        #[rustfmt::skip]
+        let mut board = array![
+            [Tile::Floor, Tile::Floor, Tile::Floor, Tile::Floor, Tile::Floor],
+            [Tile::Floor, Tile::Wall, Tile::Wall, Tile::Wall, Tile::Floor],
+            [Tile::Floor, Tile::Wall, Tile::Goal, Tile::Wall, Tile::Floor],
+            [Tile::Floor, Tile::Wall, Tile::Wall, Tile::Wall, Tile::Floor],
+            [Tile::Floor, Tile::Floor, Tile::Floor, Tile::Floor, Tile::Floor],
+        ];
+
+        // Apply culling
+        cull_outer_tiles(&mut board);
+
+        // Expected board after culling recursively
+        #[rustfmt::skip]
+        let expected = array![
+            [Tile::Empty, Tile::Empty, Tile::Empty, Tile::Empty, Tile::Empty],
+            [Tile::Empty, Tile::Wall, Tile::Wall, Tile::Wall, Tile::Empty],
+            [Tile::Empty, Tile::Wall, Tile::Goal, Tile::Wall, Tile::Empty],
+            [Tile::Empty, Tile::Wall, Tile::Wall, Tile::Wall, Tile::Empty],
+            [Tile::Empty, Tile::Empty, Tile::Empty, Tile::Empty, Tile::Empty],
+        ];
+
+        assert_eq!(board, expected);
+    }
+
+    #[test]
+    fn test_cull_tiles_not_connected_to_edge() {
+        // Create a board where inner floor tiles are isolated from the edge
+        #[rustfmt::skip]
+        let mut board = array![
+            [Tile::Wall, Tile::Wall, Tile::Wall, Tile::Wall, Tile::Wall],
+            [Tile::Wall, Tile::Floor, Tile::Floor, Tile::Floor, Tile::Wall],
+            [Tile::Wall, Tile::Floor, Tile::Goal, Tile::Floor, Tile::Wall],
+            [Tile::Wall, Tile::Floor, Tile::Floor, Tile::Floor, Tile::Wall],
+            [Tile::Wall, Tile::Wall, Tile::Wall, Tile::Wall, Tile::Wall],
+        ];
+
+        // Apply culling
+        cull_outer_tiles(&mut board);
+
+        // Expected board remains the same since the Floor tiles are not connected to the edge
+        let expected = board.clone();
+        assert_eq!(board, expected);
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -98,7 +98,7 @@ pub enum Zoom {
     Far,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Tile {
     Empty,
     Floor,

--- a/src/types.rs
+++ b/src/types.rs
@@ -101,6 +101,7 @@ pub enum Zoom {
 #[derive(Debug, Clone)]
 pub enum Tile {
     Empty,
+    Floor,
     Wall,
     Goal,
 }
@@ -194,7 +195,8 @@ impl Tile {
         match self {
             Tile::Wall => Some(get_color(TolColor::LigLightBlue)),
             Tile::Goal => Some(get_color(TolColor::BriGrey)),
-            Tile::Empty => Some(get_color(TolColor::CstLigBlue)),
+            Tile::Floor => Some(get_color(TolColor::CstLigBlue)),
+            Tile::Empty => None,
         }
     }
 }


### PR DESCRIPTION
The sokoban level format doesn't encode a difference between floor tiles and empty tiles. This adds an algorithm that will cull any floor tiles from the board that should be empty.

There are two case in which a Floor tile should be Empty:

1. The Floor tile is directly adjacent to an Edge
2. The Floor tile is directly adjacent to an Empty tile

The full algorithm works by recursively culling Floor tiles starting with the floor tiles on the perimeter of the board.